### PR TITLE
Fixed default scheme name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ public class Startup
 		// Add the API Key authentication here..
 		// AddApiKeyInHeaderOrQueryParams extension takes an implementation of IApiKeyProvider for validating the key. 
 		// It also requires Realm and KeyName to be set in the options.
-		services.AddAuthentication(BasicDefaults.AuthenticationScheme)
+		services.AddAuthentication(ApiKeyDefaults.AuthenticationScheme)
 			//// use below to accept API Key either in header or query parameter
 			.AddApiKeyInHeaderOrQueryParams<ApiKeyProvider>(options => 
 			{ 


### PR DESCRIPTION
Default scheme name in documentation was referring to a non-existent location. Fixed the reference to point to the correct file.