### PR TITLE
 Validate key against the key that comes through the request

### DIFF
--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyExtensions.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyExtensions.cs
@@ -62,6 +62,10 @@ namespace AspNetCore.Authentication.ApiKey
 			// Adds implementation of IBasicUserValidationService to the dependency container.
 			builder.Services.AddTransient<IApiKeyProvider, TApiKeyProvider>();
 
+			// Adds a default validation for Api keys. 
+			// If a different implementation for IApiKeyValidator is needed then that other implementation just has to be registered afterwards
+			builder.Services.AddTransient<IApiKeyValidator, ApiKeyValidator>();
+
 			// Adds basic authentication scheme to the pipeline.
 			return builder.AddScheme<ApiKeyOptions, TApiKeyHandler>(ApiKeyDefaults.AuthenticationScheme, configureOptions);
 		}

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
@@ -13,73 +13,73 @@ using System.Threading.Tasks;
 
 namespace AspNetCore.Authentication.ApiKey
 {
-    /// <summary>
-    /// Inherited from <see cref="AuthenticationHandler{TOptions}"/> for api key authentication.
-    /// </summary>
-    internal abstract class ApiKeyHandlerBase : AuthenticationHandler<ApiKeyOptions>
-    {
-        private readonly IApiKeyProvider _apiKeyValidationService;
+	/// <summary>
+	/// Inherited from <see cref="AuthenticationHandler{TOptions}"/> for api key authentication.
+	/// </summary>
+	internal abstract class ApiKeyHandlerBase : AuthenticationHandler<ApiKeyOptions>
+	{
+		private readonly IApiKeyProvider _apiKeyValidationService;
 
-        protected ApiKeyHandlerBase(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService)
-            : base(options, logger, encoder, clock)
-        {
-            _apiKeyValidationService = apiKeyValidationService;
-        }
+		protected ApiKeyHandlerBase(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService)
+			: base(options, logger, encoder, clock)
+		{
+			_apiKeyValidationService = apiKeyValidationService;
+		}
 
-        protected abstract string AuthenticationScheme { get; }
+		protected abstract string AuthenticationScheme { get; }
 
-        private string Challenge => $"{AuthenticationScheme} realm=\"{Options.Realm}\", charset=\"UTF-8\"";
+		private string Challenge => $"{AuthenticationScheme} realm=\"{Options.Realm}\", charset=\"UTF-8\"";
 
-        protected async Task<AuthenticateResult> HandleAuthenticateAsync(string key)
-        {
-            if (string.IsNullOrWhiteSpace(key))
-            {
-                return AuthenticateResult.Fail("Invalid ApiKey authentication header.");
-            }
+		protected async Task<AuthenticateResult> HandleAuthenticateAsync(string key)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+			{
+				return AuthenticateResult.Fail("Invalid ApiKey authentication header.");
+			}
 
-            // Validate key by using the implementation of IApiKeyValidationService.
-            var validatedKey = await _apiKeyValidationService.ProvideAsync(key).ConfigureAwait(false);
-            if (validatedKey == null)
-            {
-                return AuthenticateResult.Fail("Invalid API Key provided.");
-            }
+			// Validate key by using the implementation of IApiKeyValidationService.
+			var validatedKey = await _apiKeyValidationService.ProvideAsync(key).ConfigureAwait(false);
+			if (validatedKey == null)
+			{
+				return AuthenticateResult.Fail("Invalid API Key provided.");
+			}
 
-            // Validate key against the key that comes through the request
-            if (!String.Equals(validatedKey.Key, key))
-            {
-                return AuthenticateResult.Fail("Invalid API Key provided.");
-            }
+			// Validate key against the key that comes through the request
+			if (!String.Equals(validatedKey.Key, key))
+			{
+				return AuthenticateResult.Fail("Invalid API Key provided.");
+			}
 
-            // Create 'AuthenticationTicket' and return as success if the above validation was successful.
-            var claims = new List<Claim>();
-            if (validatedKey.Claims != null)
-            {
-                claims.AddRange(validatedKey.Claims);
-            }
+			// Create 'AuthenticationTicket' and return as success if the above validation was successful.
+			var claims = new List<Claim>();
+			if (validatedKey.Claims != null)
+			{
+				claims.AddRange(validatedKey.Claims);
+			}
 
-            if (!string.IsNullOrWhiteSpace(validatedKey.OwnerName) && !claims.Exists(c => c.Type.Equals(ClaimTypes.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-                claims.Add(new Claim(ClaimTypes.Name, validatedKey.OwnerName));
-            }
+			if (!string.IsNullOrWhiteSpace(validatedKey.OwnerName) && !claims.Exists(c => c.Type.Equals(ClaimTypes.Name, StringComparison.OrdinalIgnoreCase)))
+			{
+				claims.Add(new Claim(ClaimTypes.Name, validatedKey.OwnerName));
+			}
 
-            var identity = new ClaimsIdentity(claims, Scheme.Name);
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, Scheme.Name);
-            return AuthenticateResult.Success(ticket);
-        }
+			var identity = new ClaimsIdentity(claims, Scheme.Name);
+			var principal = new ClaimsPrincipal(identity);
+			var ticket = new AuthenticationTicket(principal, Scheme.Name);
+			return AuthenticateResult.Success(ticket);
+		}
 
-        /// <summary>
-        /// Handles the un-authenticated requests.
-        /// Returns 401 status code in response.
-        /// Adds 'WWW-Authenticate' with 'Basic' authentication scheme and 'Realm' in the response header
-        /// to let the client know that 'Basic' authentication scheme is being used by the system.
-        /// </summary>
-        /// <param name="properties"></param>
-        /// <returns></returns>
-        protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
-        {
-            Response.Headers[HeaderNames.WWWAuthenticate] = Challenge;
-            await base.HandleChallengeAsync(properties);
-        }
-    }
+		/// <summary>
+		/// Handles the un-authenticated requests. 
+		/// Returns 401 status code in response.
+		/// Adds 'WWW-Authenticate' with 'Basic' authentication scheme and 'Realm' in the response header 
+		/// to let the client know that 'Basic' authentication scheme is being used by the system.
+		/// </summary>
+		/// <param name="properties"></param>
+		/// <returns></returns>
+		protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
+		{
+			Response.Headers[HeaderNames.WWWAuthenticate] = Challenge;
+			await base.HandleChallengeAsync(properties);
+		}
+	}
 }

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
@@ -44,6 +44,12 @@ namespace AspNetCore.Authentication.ApiKey
 				return AuthenticateResult.Fail("Invalid API Key provided.");
 			}
 
+			// Validate key against the key that comes through the request
+			if (!String.Equals(validatedKey.Key, key))
+            {
+				return AuthenticateResult.Fail("Invalid API Key provided.");
+			}
+
 			// Create 'AuthenticationTicket' and return as success if the above validation was successful.
 			var claims = new List<Claim>();
 			if (validatedKey.Claims != null)

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
@@ -13,73 +13,73 @@ using System.Threading.Tasks;
 
 namespace AspNetCore.Authentication.ApiKey
 {
-	/// <summary>
-	/// Inherited from <see cref="AuthenticationHandler{TOptions}"/> for api key authentication.
-	/// </summary>
-	internal abstract class ApiKeyHandlerBase : AuthenticationHandler<ApiKeyOptions>
-	{
-		private readonly IApiKeyProvider _apiKeyValidationService;
+    /// <summary>
+    /// Inherited from <see cref="AuthenticationHandler{TOptions}"/> for api key authentication.
+    /// </summary>
+    internal abstract class ApiKeyHandlerBase : AuthenticationHandler<ApiKeyOptions>
+    {
+        private readonly IApiKeyProvider _apiKeyValidationService;
 
-		protected ApiKeyHandlerBase(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService) 
-			: base(options, logger, encoder, clock)
-		{
-			_apiKeyValidationService = apiKeyValidationService;
-		}
+        protected ApiKeyHandlerBase(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService)
+            : base(options, logger, encoder, clock)
+        {
+            _apiKeyValidationService = apiKeyValidationService;
+        }
 
-		protected abstract string AuthenticationScheme { get; }
+        protected abstract string AuthenticationScheme { get; }
 
-		private string Challenge => $"{AuthenticationScheme} realm=\"{Options.Realm}\", charset=\"UTF-8\"";
+        private string Challenge => $"{AuthenticationScheme} realm=\"{Options.Realm}\", charset=\"UTF-8\"";
 
-		protected async Task<AuthenticateResult> HandleAuthenticateAsync(string key)
-		{
-			if (string.IsNullOrWhiteSpace(key))
-			{
-				return AuthenticateResult.Fail("Invalid ApiKey authentication header.");
-			}
-
-			// Validate key by using the implementation of IApiKeyValidationService.
-			var validatedKey = await _apiKeyValidationService.ProvideAsync(key).ConfigureAwait(false);
-			if (validatedKey == null)
-			{
-				return AuthenticateResult.Fail("Invalid API Key provided.");
-			}
-
-			// Validate key against the key that comes through the request
-			if (!String.Equals(validatedKey.Key, key))
+        protected async Task<AuthenticateResult> HandleAuthenticateAsync(string key)
+        {
+            if (string.IsNullOrWhiteSpace(key))
             {
-				return AuthenticateResult.Fail("Invalid API Key provided.");
-			}
+                return AuthenticateResult.Fail("Invalid ApiKey authentication header.");
+            }
 
-			// Create 'AuthenticationTicket' and return as success if the above validation was successful.
-			var claims = new List<Claim>();
-			if (validatedKey.Claims != null)
-			{
-				claims.AddRange(validatedKey.Claims);
-			}
+            // Validate key by using the implementation of IApiKeyValidationService.
+            var validatedKey = await _apiKeyValidationService.ProvideAsync(key).ConfigureAwait(false);
+            if (validatedKey == null)
+            {
+                return AuthenticateResult.Fail("Invalid API Key provided.");
+            }
 
-			if (!string.IsNullOrWhiteSpace(validatedKey.OwnerName) && !claims.Exists(c => c.Type.Equals(ClaimTypes.Name, StringComparison.OrdinalIgnoreCase)))
-			{
-				claims.Add(new Claim(ClaimTypes.Name, validatedKey.OwnerName));
-			}
+            // Validate key against the key that comes through the request
+            if (!String.Equals(validatedKey.Key, key))
+            {
+                return AuthenticateResult.Fail("Invalid API Key provided.");
+            }
 
-			var identity = new ClaimsIdentity(claims, Scheme.Name);
-			var principal = new ClaimsPrincipal(identity);
-			var ticket = new AuthenticationTicket(principal, Scheme.Name);
-			return AuthenticateResult.Success(ticket);
-		}
+            // Create 'AuthenticationTicket' and return as success if the above validation was successful.
+            var claims = new List<Claim>();
+            if (validatedKey.Claims != null)
+            {
+                claims.AddRange(validatedKey.Claims);
+            }
 
-		/// <summary>
-		/// Handles the un-authenticated requests. 
-		/// Returns 401 status code in response.
-		/// Adds 'WWW-Authenticate' with 'Basic' authentication scheme and 'Realm' in the response header 
-		/// to let the client know that 'Basic' authentication scheme is being used by the system.
-		/// </summary>
-		/// <param name="properties"></param>
-		/// <returns></returns>
-		protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
-		{
-			Response.Headers[HeaderNames.WWWAuthenticate] = Challenge;
-			await base.HandleChallengeAsync(properties);
-		}
-	}
+            if (!string.IsNullOrWhiteSpace(validatedKey.OwnerName) && !claims.Exists(c => c.Type.Equals(ClaimTypes.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                claims.Add(new Claim(ClaimTypes.Name, validatedKey.OwnerName));
+            }
+
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            return AuthenticateResult.Success(ticket);
+        }
+
+        /// <summary>
+        /// Handles the un-authenticated requests.
+        /// Returns 401 status code in response.
+        /// Adds 'WWW-Authenticate' with 'Basic' authentication scheme and 'Realm' in the response header
+        /// to let the client know that 'Basic' authentication scheme is being used by the system.
+        /// </summary>
+        /// <param name="properties"></param>
+        /// <returns></returns>
+        protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
+        {
+            Response.Headers[HeaderNames.WWWAuthenticate] = Challenge;
+            await base.HandleChallengeAsync(properties);
+        }
+    }
 }

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
@@ -38,7 +38,7 @@ namespace AspNetCore.Authentication.ApiKey
 			}
 
 			// Validate key by using the implementation of IApiKeyValidationService.
-			var validatedKey = await _apiKeyValidationService.ProvideAsync(key).ConfigureAwait(false);
+			var validatedKey = await _apiKeyValidationService.ProvideAsync().ConfigureAwait(false);
 			if (validatedKey == null)
 			{
 				return AuthenticateResult.Fail("Invalid API Key provided.");

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyHandlerBase.cs
@@ -19,11 +19,13 @@ namespace AspNetCore.Authentication.ApiKey
 	internal abstract class ApiKeyHandlerBase : AuthenticationHandler<ApiKeyOptions>
 	{
 		private readonly IApiKeyProvider _apiKeyValidationService;
+		private readonly IApiKeyValidator _apiKeyValidator;
 
-		protected ApiKeyHandlerBase(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService)
+		protected ApiKeyHandlerBase(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService, IApiKeyValidator apiKeyValidator)
 			: base(options, logger, encoder, clock)
 		{
 			_apiKeyValidationService = apiKeyValidationService;
+			_apiKeyValidator = apiKeyValidator;
 		}
 
 		protected abstract string AuthenticationScheme { get; }
@@ -44,8 +46,10 @@ namespace AspNetCore.Authentication.ApiKey
 				return AuthenticateResult.Fail("Invalid API Key provided.");
 			}
 
+			
+
 			// Validate key against the key that comes through the request
-			if (!String.Equals(validatedKey.Key, key))
+			if (!_apiKeyValidator.IsValidKey(validatedKey, key))
 			{
 				return AuthenticateResult.Fail("Invalid API Key provided.");
 			}

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyInHeaderHandler.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyInHeaderHandler.cs
@@ -12,8 +12,8 @@ namespace AspNetCore.Authentication.ApiKey
 {
 	internal class ApiKeyInHeaderHandler : ApiKeyHandlerBase
 	{
-		public ApiKeyInHeaderHandler(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService) 
-			: base(options, logger, encoder, clock, apiKeyValidationService)
+		public ApiKeyInHeaderHandler(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService, IApiKeyValidator apiKeyValidator) 
+			: base(options, logger, encoder, clock, apiKeyValidationService, apiKeyValidator)
 		{
 		}
 

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyInHeaderOrQueryParamsHandler.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyInHeaderOrQueryParamsHandler.cs
@@ -12,8 +12,8 @@ namespace AspNetCore.Authentication.ApiKey
 {
 	internal class ApiKeyInHeaderOrQueryParamsHandler : ApiKeyHandlerBase
 	{
-		public ApiKeyInHeaderOrQueryParamsHandler(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService) 
-			: base(options, logger, encoder, clock, apiKeyValidationService)
+		public ApiKeyInHeaderOrQueryParamsHandler(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService, IApiKeyValidator apiKeyValidator) 
+			: base(options, logger, encoder, clock, apiKeyValidationService, apiKeyValidator)
 		{
 		}
 

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyInQueryParamsHandler.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyInQueryParamsHandler.cs
@@ -12,8 +12,8 @@ namespace AspNetCore.Authentication.ApiKey
 {
 	internal class ApiKeyInQueryParamsHandler : ApiKeyHandlerBase
 	{
-		public ApiKeyInQueryParamsHandler(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService)
-			: base(options, logger, encoder, clock, apiKeyValidationService)
+		public ApiKeyInQueryParamsHandler(IOptionsMonitor<ApiKeyOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IApiKeyProvider apiKeyValidationService, IApiKeyValidator apiKeyValidator)
+			: base(options, logger, encoder, clock, apiKeyValidationService, apiKeyValidator)
 		{
 		}
 

--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyValidator.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyValidator.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AspNetCore.Authentication.ApiKey
+{
+    public class ApiKeyValidator: IApiKeyValidator
+    {
+        public bool IsValidKey(IApiKey apiKey, string key)
+        {
+            if ((apiKey?.Key == null) || String.IsNullOrWhiteSpace(key))
+            {
+                return false;
+            }
+
+            return (apiKey.Key.FirstOrDefault(ak => String.Equals(ak, key, apiKey.StringComparison)) !=  null);
+           
+        }
+    }
+}

--- a/src/AspNetCore.Authentication.ApiKey/IApiKey.cs
+++ b/src/AspNetCore.Authentication.ApiKey/IApiKey.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Mihir Dilip. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 
@@ -14,7 +15,9 @@ namespace AspNetCore.Authentication.ApiKey
 		/// <summary>
 		/// API Key
 		/// </summary>
-		string Key { get; }
+		IEnumerable<string> Key { get; }
+
+		StringComparison StringComparison { get; }
 
 		/// <summary>
 		/// Owner of the API Key. It can be username or any other key owner name.

--- a/src/AspNetCore.Authentication.ApiKey/IApiKeyProvider.cs
+++ b/src/AspNetCore.Authentication.ApiKey/IApiKeyProvider.cs
@@ -15,6 +15,6 @@ namespace AspNetCore.Authentication.ApiKey
 		/// </summary>
 		/// <param name="key"></param>
 		/// <returns></returns>
-		Task<IApiKey> ProvideAsync(string key);
+		Task<IApiKey> ProvideAsync();
 	}
 }

--- a/src/AspNetCore.Authentication.ApiKey/IApiKeyValidator.cs
+++ b/src/AspNetCore.Authentication.ApiKey/IApiKeyValidator.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AspNetCore.Authentication.ApiKey
+{
+    public interface IApiKeyValidator
+    {
+        bool IsValidKey(IApiKey apiKey, string key);
+    }
+}


### PR DESCRIPTION
Hello @mihirdilip ,
thanks for your effort to provide a DotNet Core AuthenticationHandler.
I think I found a bug or at least something that leads to an unwanted behaviour.
To demonstrate that, I created a sample project in which I use the AspNetCore.Authentication.ApiKey library which can be found here:
https://github.com/bleissem/aspnetcore-authentication-apikey-sample
It's just a standard DotNet Core Sample Application with an Authorize Attribute above the WeatherForecastController.

The secret Api Key is stored inside the [appsettings.json ](https://github.com/bleissem/aspnetcore-authentication-apikey-sample/blob/master/WebApplication1/appsettings.json
). 
`
"AppOptions": {
    "ApiKey": "1234"
  }
`

That AppOptions are then injected into the [ApiKey](https://github.com/bleissem/aspnetcore-authentication-apikey-sample/blob/master/WebApplication1/ApiKey.cs) class and the api key is then stored inside the Key property that is needed by the [ IApiKey](https://github.com/mihirdilip/aspnetcore-authentication-apikey/blob/master/src/AspNetCore.Authentication.ApiKey/IApiKey.cs) Interface. 
Also the ApiKey object is injected to the [ApiKeyProvider](https://github.com/bleissem/aspnetcore-authentication-apikey-sample/blob/master/WebApplication1/ApiKeyProvider.cs) class that has been registered in [Startup](https://github.com/bleissem/aspnetcore-authentication-apikey-sample/blob/master/WebApplication1/Startup.cs) class.

`
services.AddTransient<IApiKey, ApiKey>();

services.AddAuthentication(ApiKeyDefaults.AuthenticationScheme)
.AddApiKeyInHeaderOrQueryParams<ApiKeyProvider>(options =>
{
	options.Realm = "My App";
	options.KeyName = nameof(AppOptions.ApiKey);
});
`

When I use Postman to check if everything works, then everything works fine with the [correct api key](https://github.com/bleissem/aspnetcore-authentication-apikey-sample/blob/master/media/postmancallwithcorrectvalue.jpg).

The problem comes when a [wrong api key](https://github.com/bleissem/aspnetcore-authentication-apikey-sample/blob/master/media/postmancallwithwrongvalue.jpg) is used. The call is also authorized although a wrong api key comes through the Postman request. 

The AspNetCore.Authentication.ApiKey library simply does not check the key that comes through the request against the key that comes (in my case) from the [appsettings.json ](https://github.com/bleissem/aspnetcore-authentication-apikey-sample/blob/master/WebApplication1/appsettings.json
).
So I think checking those values is something that should be done by AspNetCore.Authentication.ApiKey library.

Regards
Alex B.
PS. sorry for the missing blanks in the code. Somehow my VS doesn't get the proper formating done. 