### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ public class ApiKeyProvider : IApiKeyProvider
 	{
 		try
 		{
-			// write your validation implementation here and return an instance of a valid ApiKey or return an task with a null result for an invalid key.
+			// write your validation implementation here and return an instance of a valid ApiKey or return a task with a null result for an invalid key.
 			// return await _apiKeyRepository.GetApiKeyAsync(key);
 			return Task.FromResult<IApiKey>(null);
 		}

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ public class ApiKeyProvider : IApiKeyProvider
 	{
 		try
 		{
-			// write your validation implementation here and return an instance of a valid ApiKey or retun null for an invalid key.
+			// write your validation implementation here and return an instance of a valid ApiKey or return an empty task for an invalid key.
 			// return await _apiKeyRepository.GetApiKeyAsync(key);
-			return null;
+			return Task.FromResult<IApiKey>(null);
 		}
 		catch (System.Exception exception)
 		{

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ public class ApiKeyProvider : IApiKeyProvider
 	{
 		try
 		{
-			// write your validation implementation here and return an instance of a valid ApiKey or return an empty task for an invalid key.
+			// write your validation implementation here and return an instance of a valid ApiKey or return an task with a null result for an invalid key.
 			// return await _apiKeyRepository.GetApiKeyAsync(key);
 			return Task.FromResult<IApiKey>(null);
 		}


### PR DESCRIPTION
Issue:

The README advises returning `null` from the `IApiKeyProvider.ProvideAsync(string)` method when the key from the request is not valid. This results in an exception being raised in the following method:

![image](https://user-images.githubusercontent.com/47836784/133732327-f480fa1b-cf1d-4e2b-8d6e-680e62f9c4f9.png)

From there you get a 500 response rather than a 401.

Resolution:

Returning a task with a null result addresses the issue and ensures a 401 response is returned in the event of an invalid key