### PR TITLE
Pass CancellationToken to ProvideAsync(...)

### DIFF
--- a/src/AspNetCore.Authentication.ApiKey/ApiKeyOptions.cs
+++ b/src/AspNetCore.Authentication.ApiKey/ApiKeyOptions.cs
@@ -50,7 +50,7 @@ namespace AspNetCore.Authentication.ApiKey
 
         /// <summary>
         /// Default value is false. 
-        /// If set to true, <see cref="IApiKey.Key"/> property returned from <see cref="IApiKeyProvider.ProvideAsync(string)"/> method is not compared with the key parsed from the request.
+        /// If set to true, <see cref="IApiKey.Key"/> property returned from <see cref="IApiKeyProvider.ProvideAsync(string, CancellationToken)"/> method is not compared with the key parsed from the request.
         /// This extra check did not existed in the previous version. So you if want to revert back to old version validation, please set this to true.
         /// </summary>
         public bool ForLegacyIgnoreExtraValidatedApiKeyCheck { get; set; }

--- a/src/AspNetCore.Authentication.ApiKey/IApiKeyProvider.cs
+++ b/src/AspNetCore.Authentication.ApiKey/IApiKeyProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Mihir Dilip. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AspNetCore.Authentication.ApiKey
@@ -14,7 +15,8 @@ namespace AspNetCore.Authentication.ApiKey
 		/// Validates the key and provides with and instance of <see cref="IApiKey"/>.
 		/// </summary>
 		/// <param name="key"></param>
+		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		Task<IApiKey> ProvideAsync(string key);
+		Task<IApiKey> ProvideAsync(string key, CancellationToken cancellationToken);
 	}
 }

--- a/test/AspNetCore.Authentication.ApiKey.Tests/ApiKeyExtensionsTests.cs
+++ b/test/AspNetCore.Authentication.ApiKey.Tests/ApiKeyExtensionsTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -1203,7 +1204,7 @@ namespace AspNetCore.Authentication.ApiKey.Tests
 
         private class MockApiKeyProvider : IApiKeyProvider
         {
-            public Task<IApiKey> ProvideAsync(string key)
+            public Task<IApiKey> ProvideAsync(string key, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }
@@ -1211,7 +1212,7 @@ namespace AspNetCore.Authentication.ApiKey.Tests
 
         private class MockApiKeyProvider2 : IApiKeyProvider
         {
-            public Task<IApiKey> ProvideAsync(string key)
+            public Task<IApiKey> ProvideAsync(string key, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }

--- a/test/AspNetCore.Authentication.ApiKey.Tests/ApiKeyHandlerBaseTests.cs
+++ b/test/AspNetCore.Authentication.ApiKey.Tests/ApiKeyHandlerBaseTests.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -504,7 +505,7 @@ namespace AspNetCore.Authentication.ApiKey.Tests
 
         private class FakeApiKeyProviderLocal_1 : IApiKeyProvider
         {
-            public Task<IApiKey> ProvideAsync(string key)
+            public Task<IApiKey> ProvideAsync(string key, CancellationToken cancellationToken)
             {
 				return Task.FromResult((IApiKey)new FakeApiKey(key, "Test", new List<Claim> { new Claim("Provider", "1") }));
             }
@@ -512,7 +513,7 @@ namespace AspNetCore.Authentication.ApiKey.Tests
 
 		private class FakeApiKeyProviderLocal_2 : IApiKeyProvider
 		{
-			public Task<IApiKey> ProvideAsync(string key)
+			public Task<IApiKey> ProvideAsync(string key, CancellationToken cancellationToken)
 			{
 				return Task.FromResult((IApiKey)new FakeApiKey(key, "Test", new List<Claim> { new Claim("Provider", "2") }));
 			}

--- a/test/AspNetCore.Authentication.ApiKey.Tests/Infrastructure/FakeApiKeyProvider.cs
+++ b/test/AspNetCore.Authentication.ApiKey.Tests/Infrastructure/FakeApiKeyProvider.cs
@@ -5,13 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AspNetCore.Authentication.ApiKey.Tests.Infrastructure
 {
     class FakeApiKeyProvider : IApiKeyProvider
     {
-        public Task<IApiKey> ProvideAsync(string key)
+        public Task<IApiKey> ProvideAsync(string key, CancellationToken cancellationToken)
         {
             var apiKey = FakeApiKeys.Keys.FirstOrDefault(k => k.Key.Equals(key, StringComparison.OrdinalIgnoreCase));
             if (apiKey != null)


### PR DESCRIPTION
When there is a long running operation, this helps cancel it if the request is aborted. For example, a database query.